### PR TITLE
docs:fix github action badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/upbin.svg)](https://www.npmjs.com/package/upbin)
 [![license](https://img.shields.io/github/license/Leko/upbin.svg)](https://opensource.org/licenses/MIT)
-[![GitHub Actions(https://github.com/actions/Leko/upbin/workflows/test-and-lint/badge.svg)](https://github.com/Leko/upbin/actions)
+[![Lint and Test](https://github.com/Leko/upbin/workflows/Lint%20and%20Test/badge.svg)](https://github.com/Leko/upbin/actions)
 [![codecov](https://codecov.io/gh/Leko/upbin/branch/master/graph/badge.svg)](https://codecov.io/gh/Leko/upbin) [![Greenkeeper badge](https://badges.greenkeeper.io/Leko/upbin.svg)](https://greenkeeper.io/)
 
 CLI helper to find and execute an executable file by walking up parent directories.


### PR DESCRIPTION
Github action badge had a broken image.
Fixed the URL so the badge is displayed correctly